### PR TITLE
Dump attributes before typecast - Fixes Enums

### DIFF
--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -73,7 +73,7 @@ module Dumpable
       keys = key_values.collect{ |item| "`#{item[0]}`" }.join(", ")
       values = key_values.collect{ |item| item[1].to_s }.join(", ")
 
-      "INSERT INTO #{object.class.table_name} (#{ keys }) VALUES (#{ values }) ON DUPLICATE KEY UPDATE id=id;"
+      "INSERT IGNORE INTO #{object.class.table_name} (#{ keys }) VALUES (#{ values });"
     end
 
     # http://invisipunk.blogspot.com/2008/04/activerecord-raw-insertupdate.html

--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -46,9 +46,9 @@ module Dumpable
         end
       elsif dumps.is_a?(Symbol) || dumps.is_a?(String)
         Array(object.send(dumps)).each do |child_object|
-          reflection = object.class.reflections[dumps.to_sym]
+          reflection = object.class.reflections[dumps.to_s]
           if reflection.macro == :belongs_to
-            object.send("#{reflection.association_foreign_key}=", object.id + @id_padding)
+            object.send("#{reflection.association_foreign_key}=", child_object.id + @id_padding)
           elsif [:has_many, :has_one].include? reflection.macro
             if reflection.respond_to?(:foreign_key)
               child_object.send("#{reflection.foreign_key}=", object.id + @id_padding)
@@ -91,8 +91,8 @@ module Dumpable
           '0'
         when "TrueClass"
           '1'
-        when "ActiveSupport::HashWithIndifferentAccess"
-          "'#{value.to_yaml.gsub(/'/, "\\\\'")}'"
+        when "Array", "Hash"
+          "'#{value.to_json.gsub(/'/, "''").gsub("\\", "\\\\\\")}'"
         else
           "'#{value}'"
       end

--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -73,7 +73,7 @@ module Dumpable
       keys = key_values.collect{ |item| "`#{item[0]}`" }.join(", ")
       values = key_values.collect{ |item| item[1].to_s }.join(", ")
 
-      "INSERT IGNORE INTO #{object.class.table_name} (#{ keys }) VALUES (#{ values });"
+      "INSERT INTO #{object.class.table_name} (#{ keys }) VALUES (#{ values }) ON DUPLICATE KEY UPDATE id=id;"
     end
 
     # http://invisipunk.blogspot.com/2008/04/activerecord-raw-insertupdate.html

--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -48,7 +48,7 @@ module Dumpable
         Array(object.send(dumps)).each do |child_object|
           reflection = object.class.reflections[dumps.to_s]
           if reflection.macro == :belongs_to
-            object.send("#{reflection.association_foreign_key}=", child_object.id + @id_padding)
+            object.send("#{reflection.foreign_key}=", child_object.id + @id_padding)
           elsif [:has_many, :has_one].include? reflection.macro
             if reflection.respond_to?(:foreign_key)
               child_object.send("#{reflection.foreign_key}=", object.id + @id_padding)

--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -86,7 +86,7 @@ module Dumpable
         when "Fixnum"
           value
         when "String"
-          "'#{value.gsub(/'/, "\\\\'")}'"
+          "'#{value.gsub(/'/, "''").gsub("\\", "\\\\\\")}'"
         when "FalseClass"
           '0'
         when "TrueClass"

--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -64,7 +64,7 @@ module Dumpable
     # http://invisipunk.blogspot.com/2008/04/activerecord-raw-insertupdate.html
     def generate_insert_query(object)
       skip_columns = Array(@options[:skip_columns] || (object.class.respond_to?(:dumpable_options) && object.class.dumpable_options[:skip_columns])).map(&:to_s)
-      cloned_attributes = object.attributes.clone
+      cloned_attributes = object.attributes_before_type_cast.clone
       return nil unless cloned_attributes["id"].present?
       cloned_attributes["id"] += @id_padding
       key_values = cloned_attributes.collect do |key,value|

--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -73,7 +73,7 @@ module Dumpable
       keys = key_values.collect{ |item| "`#{item[0]}`" }.join(", ")
       values = key_values.collect{ |item| item[1].to_s }.join(", ")
 
-      "INSERT INTO #{object.class.table_name} (#{ keys }) VALUES (#{ values });"
+      "INSERT IGNORE INTO #{object.class.table_name} (#{ keys }) VALUES (#{ values });"
     end
 
     # http://invisipunk.blogspot.com/2008/04/activerecord-raw-insertupdate.html


### PR DESCRIPTION
Currently, model attributes set as enums will be dumped with the enum string value instead of the integer value.

Consider the following model:
```ruby
class Comment < ActiveRecord::Base
   enum :status => [:draft, :published]
end
```

Would be dumped with the status attribute being either  `"draft"` or `"published"`

```sql
# incorrect
INSERT IGNORE INTO comments (`id`, `status`, `text`) VALUES ('48', 'draft', 'some text');
```

This Pull request use s `attributes_before_type_cast` to get the attributes as they were read from the database, thereby maintaining the original types.
```sql
# correct
INSERT IGNORE INTO comments (`id`, `status`, `text`) VALUES ('48', '0', 'some text');
```
