### PR TITLE
Dump attributes before typecast - Fixes Enums

### DIFF
--- a/lib/dumpable/dumper.rb
+++ b/lib/dumpable/dumper.rb
@@ -64,7 +64,7 @@ module Dumpable
     # http://invisipunk.blogspot.com/2008/04/activerecord-raw-insertupdate.html
     def generate_insert_query(object)
       skip_columns = Array(@options[:skip_columns] || (object.class.respond_to?(:dumpable_options) && object.class.dumpable_options[:skip_columns])).map(&:to_s)
-      cloned_attributes = object.attributes.clone
+      cloned_attributes = object.attributes_before_type_cast.clone
       return nil unless cloned_attributes["id"].present?
       cloned_attributes["id"] += @id_padding
       key_values = cloned_attributes.collect do |key,value|


### PR DESCRIPTION
Currently, model attributes set as enums will be dumped with the enum string value instead of the integer value.

Consider the following model:
```ruby
class Comment < ActiveRecord::Base
   enum :status => [:draft, :published]
end
```

Would be dumped with the status attribute being either  `"draft"` or `"published"`

```sql
# incorrect
INSERT IGNORE INTO comments (`id`, `status`, `text`) VALUES ('48', 'draft', 'some text');
```

This Pull request use s `attributes_before_type_cast` to get the attributes as they were read from the database, thereby maintaining the original types.
```sql
# correct
INSERT IGNORE INTO comments (`id`, `status`, `text`) VALUES ('48', '0', 'some text');
```
